### PR TITLE
Fix README.md and use standard typing in noise.py

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 AlbertUnruh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ plt.show()
 ```
 
 ### Did you implement it your own?
-No, I found an example written in `C#` and I "converted" it into `Python3`.
+No, I found an example written in `C#` and I rewrote it in `Python 3`.
 If you want you can check the original code [here](http://devmag.org.za/2009/04/25/perlin-noise/) out.
 
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ from matplotlib import pyplot as plt
 plt.figure(dpi=100)
 plt.imshow(my_perlin_result, cmap="gray")
 # other cmap's I recommend to try are "gist_earth", "plasma" and "hot"
+plt.show()
 ```
 
 ### Did you implement it your own?

--- a/__init__.py
+++ b/__init__.py
@@ -1,28 +1,63 @@
 """
-MIT License
+What is this?
+This is a Perlin-Noise-Generator which can generate Perlin-Noise.
 
-Copyright (c) 2021 AlbertUnruh
+How do I use it?
+You can run following script:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+>>> from PerlinNoise import Perlin
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+>>> seed = "My Beautiful Seed :)"
+>>> # the seed is optional and has only be set if you want to have the same result
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+>>> width, height = 512, 256
+>>> # the size is optional but it's recommended to insert the values you need
+
+>>> octave = 10
+>>> # the octave is optional but note that a higher value results in a smoother Noise and needs more time to process
+
+>>> my_perlin_generator = Perlin(
+>>>     seed=seed,
+>>>     width=width,
+>>>     height=height,
+>>>     octave=octave
+>>> )
+
+>>> # call the generator by `Perlin.generate()` or directly
+>>> my_perlin_result = my_perlin_generator()
+>>> # your perlin-noise is now in a 2D-list with floats between 0 and 1
+
+
+If you want to see the result here is a quick example:
+
+>>> from matplotlib import pyplot as plt
+
+>>> plt.figure(dpi=100)
+>>> plt.imshow(my_perlin_result, cmap="gray")
+>>> # other cmap's I recommend to try are "gist_earth", "plasma" and "hot"
+>>> plt.show()
+
+Did you implement it your own?
+No, I found an example written in `C#` and I rewrote it in Python 3.
+If you want you can check the original code here: https://devmag.org.za/2009/04/25/perlin-noise/ out.
+
 """
 
 from noise import *
 
+__all__ = (
+    Perlin
+)
 
 __author__ = "AlbertUnruh"
+__copyright__ = "Copyright (c) 2021 AlbertUnruh"
+__credits__ = [
+    "AlbertUnruh",
+    "Staubfinger"
+]
+
+__license__ = "MIT"
+__version__ = "1.0.0"
+__maintainer__ = "AlbertUnruh"
+__email__ = None
+__status__ = "Production"

--- a/__init__.py
+++ b/__init__.py
@@ -45,7 +45,7 @@ If you want you can check the original code here: https://devmag.org.za/2009/04/
 
 from noise import *
 
-__all__ = (Perlin,)
+__all__ = ("Perlin",)
 
 __author__ = "AlbertUnruh"
 __copyright__ = "Copyright (c) 2021 AlbertUnruh"

--- a/__init__.py
+++ b/__init__.py
@@ -45,16 +45,11 @@ If you want you can check the original code here: https://devmag.org.za/2009/04/
 
 from noise import *
 
-__all__ = (
-    Perlin
-)
+__all__ = (Perlin,)
 
 __author__ = "AlbertUnruh"
 __copyright__ = "Copyright (c) 2021 AlbertUnruh"
-__credits__ = [
-    "AlbertUnruh",
-    "Staubfinger"
-]
+__credits__ = ["AlbertUnruh", "Staubfinger"]
 
 __license__ = "MIT"
 __version__ = "1.0.0"

--- a/noise.py
+++ b/noise.py
@@ -185,7 +185,7 @@ class Perlin:
         :class:`list[list[float]]`
             The new "smoothed noise".
         """
-        interpolate: Callable = self.interpolate
+        interpolate: Callable[[float, float, float], float] = self.interpolate
 
         noise: float2d = []
 

--- a/noise.py
+++ b/noise.py
@@ -46,22 +46,21 @@ If you want you can check the original code here: https://devmag.org.za/2009/04/
 from random import Random
 from typing import Union, Optional, Callable
 
-__all__ = (
-    "Perlin",
-)
+__all__ = ("Perlin",)
 float2d = list[list[float]]
 
 
 class Perlin:
     """The class for PerlinNoise."""
 
-    def __init__(self,
-                 *,
-                 seed: Optional[Union[str, bytes, bytearray, int, float]] = None,
-                 width: int = 128,
-                 height: int = 128,
-                 octave: int = 1
-                 ):
+    def __init__(
+        self,
+        *,
+        seed: Optional[Union[str, bytes, bytearray, int, float]] = None,
+        width: int = 128,
+        height: int = 128,
+        octave: int = 1,
+    ):
         """
         Parameters
         ----------
@@ -161,7 +160,9 @@ class Perlin:
 
         return noise
 
-    def _generate_smooth_noise(self, base: float2d, octave: Optional[int] = None) -> float2d:
+    def _generate_smooth_noise(
+        self, base: float2d, octave: Optional[int] = None
+    ) -> float2d:
         """
         Generates a smoothed noise from a blank/white noise.
 
@@ -205,12 +206,16 @@ class Perlin:
                 sample_w1: int = int(int(sample_w0 + sample_period) % width)
                 horizontal_blend: float = (w - sample_w0) * sample_frequency
 
-                top: float = interpolate(base[sample_h0][sample_w0],
-                                         base[sample_h1][sample_w0],
-                                         horizontal_blend)
-                bottom: float = interpolate(base[sample_h1][sample_w1],
-                                            base[sample_h0][sample_w1],
-                                            horizontal_blend)
+                top: float = interpolate(
+                    base[sample_h0][sample_w0],
+                    base[sample_h1][sample_w0],
+                    horizontal_blend,
+                )
+                bottom: float = interpolate(
+                    base[sample_h1][sample_w1],
+                    base[sample_h0][sample_w1],
+                    horizontal_blend,
+                )
 
                 row.append(interpolate(top, bottom, vertical_blend))
             noise.append(row)
@@ -242,12 +247,12 @@ class Perlin:
 
         octave: int = self.octave
 
-        persistence: float = .5
-        amplitude: float = 1.
+        persistence: float = 0.5
+        amplitude: float = 1.0
         total_amplitude: int = 0
 
         smooth: list[float2d] = []
-        noise: float2d = [[0. for _ in range(width)] for _ in range(height)]
+        noise: float2d = [[0.0 for _ in range(width)] for _ in range(height)]
 
         # generate smooth noise
         for o in range(octave):
@@ -271,15 +276,12 @@ class Perlin:
         return noise
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     from matplotlib import pyplot as plt
 
     square_size: int = 1 << 9
     perlin: Perlin = Perlin(
-        seed="#AU",
-        octave=20,
-        width=square_size,
-        height=square_size
+        seed="#AU", octave=20, width=square_size, height=square_size
     )
     perlin_map: float2d = perlin()
 
@@ -289,6 +291,6 @@ if __name__ == '__main__':
         # cmap="gist_earth")
         # cmap="gray")
         # cmap="plasma")
-        cmap="hot"
+        cmap="hot",
     )
     plt.show()

--- a/noise.py
+++ b/noise.py
@@ -26,18 +26,25 @@ SOFTWARE.
 Implementation followed by http://devmag.org.za/2009/04/25/perlin-noise/.
 """
 
-
 from random import Random
+from typing import Union, Optional, Callable
 
 __all__ = (
     "Perlin",
 )
+float2d = list[list[float]]
 
 
 class Perlin:
     """The class for PerlinNoise."""
 
-    def __init__(self, *, seed=None, width=128, height=128, octave=1):
+    def __init__(self,
+                 *,
+                 seed: Optional[Union[str, bytes, bytearray, int, float]] = None,
+                 width: int = 128,
+                 height: int = 128,
+                 octave: int = 1
+                 ):
         """
         Parameters
         ----------
@@ -48,12 +55,12 @@ class Perlin:
         octave: :class:`int`
             The octave for the noise generation.
         """
-        self.random = Random(seed)
+        self.random: Random = Random(seed)
         self.size = (width, height)
         self._octave = octave
 
     @property
-    def width(self):
+    def width(self) -> int:
         """
         Returns
         -------
@@ -63,7 +70,7 @@ class Perlin:
         return self.size[0]
 
     @property
-    def height(self):
+    def height(self) -> int:
         """
         Returns
         -------
@@ -73,7 +80,7 @@ class Perlin:
         return self.size[1]
 
     @property
-    def octave(self):
+    def octave(self) -> int:
         """
         Returns
         -------
@@ -82,7 +89,7 @@ class Perlin:
         """
         return self._octave
 
-    def generate(self):
+    def generate(self) -> float2d:
         """
         Generates the Perlin Noise.
 
@@ -96,7 +103,7 @@ class Perlin:
     __call__ = generate
 
     @staticmethod
-    def interpolate(x, y, /, alpha):
+    def interpolate(x: float, y: float, /, alpha: float) -> float:
         """
         Interpolates two values in dependency to :arg:`alpha`.
 
@@ -114,7 +121,7 @@ class Perlin:
         """
         return x * (1 - alpha) + alpha * y
 
-    def _generate_white_noise(self):
+    def _generate_white_noise(self) -> float2d:
         """
         Generates a blank/white noise with complete random values
         with no relationship.
@@ -124,19 +131,20 @@ class Perlin:
         :class:`list[list[float]]`
             The new generated "white noise"
         """
-        width, height = self.size  # type: int
-        random = self.random  # type: Random
-        noise = []  # type: list[list[float]]
+        width: int = self.size[0]
+        height: int = self.size[1]
+        random: Random = self.random
+        noise: float2d = []
 
         for h in range(height):
-            row = []
+            row: list[float] = []
             for w in range(width):
                 row.append(random.random() % 1)
             noise.append(row)
 
         return noise
 
-    def _generate_smooth_noise(self, base, octave=None):
+    def _generate_smooth_noise(self, base: float2d, octave: Optional[int] = None) -> float2d:
         """
         Generates a smoothed noise from a blank/white noise.
 
@@ -159,40 +167,40 @@ class Perlin:
         :class:`list[list[float]]`
             The new "smoothed noise".
         """
-        interpolate = self.interpolate
+        interpolate: Callable = self.interpolate
 
-        noise = []  # type: list[list[float]]
+        noise: float2d = []
 
-        height = len(base)  # type: int
-        width = len(base[0])  # type: int
+        height: int = len(base)
+        width: int = len(base[0])
 
-        sample_period = 1 << (octave or self.octave)  # type: int
-        sample_frequency = 1 / sample_period  # type: float
+        sample_period: int = 1 << (octave or self.octave)
+        sample_frequency: float = 1 / sample_period
 
         for h in range(height):
-            sample_h0 = int(int(h / sample_period) * sample_period)
-            sample_h1 = int(int(sample_h0 + sample_period) % height)
-            vertical_blend = (h - sample_h0) * sample_frequency
+            sample_h0: int = int(int(h / sample_period) * sample_period)
+            sample_h1: int = int(int(sample_h0 + sample_period) % height)
+            vertical_blend: float = (h - sample_h0) * sample_frequency
 
-            row = []
+            row: list[float] = []
             for w in range(width):
-                sample_w0 = int(int(w / sample_period) * sample_period)
-                sample_w1 = int(int(sample_w0 + sample_period) % width)
-                horizontal_blend = (w - sample_w0) * sample_frequency
+                sample_w0: int = int(int(w / sample_period) * sample_period)
+                sample_w1: int = int(int(sample_w0 + sample_period) % width)
+                horizontal_blend: float = (w - sample_w0) * sample_frequency
 
-                top = interpolate(base[sample_h0][sample_w0],
-                                  base[sample_h1][sample_w0],
-                                  horizontal_blend)
-                bottom = interpolate(base[sample_h1][sample_w1],
-                                     base[sample_h0][sample_w1],
-                                     horizontal_blend)
+                top: float = interpolate(base[sample_h0][sample_w0],
+                                         base[sample_h1][sample_w0],
+                                         horizontal_blend)
+                bottom: float = interpolate(base[sample_h1][sample_w1],
+                                            base[sample_h0][sample_w1],
+                                            horizontal_blend)
 
                 row.append(interpolate(top, bottom, vertical_blend))
             noise.append(row)
 
         return noise
 
-    def _generate_perlin_noise(self, base):
+    def _generate_perlin_noise(self, base: float2d) -> float2d:
         """
         Generates a perlin noise from a smoothed noise.
 
@@ -212,15 +220,17 @@ class Perlin:
         :class:`list[list[float]]`
             The new Perlin Noise.
         """
-        height = len(base)  # type: int
-        width = len(base[0])  # type: int
+        height: int = len(base)
+        width: int = len(base[0])
 
-        octave = self.octave  # type: int
+        octave: int = self.octave
 
-        persistence, amplitude, total_amplitude = .5, 1., 0
+        persistence: float = .5
+        amplitude: float = 1.
+        total_amplitude: int = 0
 
-        smooth = []  # type: list[list[list[float]]]
-        noise = [[0. for _ in range(width)] for _ in range(height)]  # type: list[list[float]]
+        smooth: list[float2d] = []
+        noise: float2d = [[0. for _ in range(width)] for _ in range(height)]
 
         # generate smooth noise
         for o in range(octave):
@@ -247,15 +257,21 @@ class Perlin:
 if __name__ == '__main__':
     from matplotlib import pyplot as plt
 
-    square_size = 1 << 9
-    perlin = Perlin(seed="#AU", octave=20,
-                    width=square_size, height=square_size)
-    perlin_map = perlin()
+    square_size: int = 1 << 9
+    perlin: Perlin = Perlin(
+        seed="#AU",
+        octave=20,
+        width=square_size,
+        height=square_size
+    )
+    perlin_map: float2d = perlin()
 
     plt.figure(dpi=square_size)
-    plt.imshow(perlin_map,
-               # cmap="gist_earth")
-               # cmap="gray")
-               # cmap="plasma")
-               cmap="hot")
+    plt.imshow(
+        perlin_map,
+        # cmap="gist_earth")
+        # cmap="gray")
+        # cmap="plasma")
+        cmap="hot"
+    )
     plt.show()

--- a/noise.py
+++ b/noise.py
@@ -1,29 +1,46 @@
 """
-MIT License
+What is this?
+This is a Perlin-Noise-Generator which can generate Perlin-Noise.
 
-Copyright (c) 2021 AlbertUnruh
+How do I use it?
+You can run following script:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+>>> from PerlinNoise import Perlin
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+>>> seed = "My Beautiful Seed :)"
+>>> # the seed is optional and has only be set if you want to have the same result
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+>>> width, height = 512, 256
+>>> # the size is optional but it's recommended to insert the values you need
 
-----------
+>>> octave = 10
+>>> # the octave is optional but note that a higher value results in a smoother Noise and needs more time to process
 
-Implementation followed by http://devmag.org.za/2009/04/25/perlin-noise/.
+>>> my_perlin_generator = Perlin(
+>>>     seed=seed,
+>>>     width=width,
+>>>     height=height,
+>>>     octave=octave
+>>> )
+
+>>> # call the generator by `Perlin.generate()` or directly
+>>> my_perlin_result = my_perlin_generator()
+>>> # your perlin-noise is now in a 2D-list with floats between 0 and 1
+
+
+If you want to see the result here is a quick example:
+
+>>> from matplotlib import pyplot as plt
+
+>>> plt.figure(dpi=100)
+>>> plt.imshow(my_perlin_result, cmap="gray")
+>>> # other cmap's I recommend to try are "gist_earth", "plasma" and "hot"
+>>> plt.show()
+
+Did you implement it your own?
+No, I found an example written in `C#` and I rewrote it in Python 3.
+If you want you can check the original code here: https://devmag.org.za/2009/04/25/perlin-noise/ out.
+
 """
 
 from random import Random

--- a/noise.py
+++ b/noise.py
@@ -258,3 +258,4 @@ if __name__ == '__main__':
                # cmap="gray")
                # cmap="plasma")
                cmap="hot")
+    plt.show()


### PR DESCRIPTION
I have Fixed a Bug in the example code of readme.md and noise.py, where matplotlib won't actually show the plot unless you specify `plt.show()` at the end.
I also added python Style type hinting using the typing module foud in the standard Libery.